### PR TITLE
Add Vitest and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "stylelint:fix": "stylelint **/*.css --fix",
     "prepare": "husky",
     "husky": "npm run stylelint && npm run eslint",
-    "commitlint": "commitlint --edit"
+    "commitlint": "commitlint --edit",
+    "test": "vitest",
+    "lint": "npm run eslint && npm run stylelint"
   },
   "dependencies": {
     "@astrojs/node": "^9.0.1",
@@ -59,7 +61,10 @@
     "prettier": "^3.5.3",
     "stylelint": "^16.19.1",
     "stylelint-config-standard": "^38.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.4.0",
+    "@astrojs/test": "^2.8.0",
+    "@testing-library/react": "^14.2.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/components/elements/Button.test.ts
+++ b/src/components/elements/Button.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@astrojs/test'
+import Button from './Button.astro'
+
+describe('Button component', () => {
+  it('renders provided label', async () => {
+    const { getByText } = await render(Button, { props: { label: 'Read more', link: { cached_url: '#' } } })
+    expect(getByText('Read more')).toBeTruthy()
+  })
+})

--- a/src/utils/lang.test.js
+++ b/src/utils/lang.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { getTransLink } from './lang'
+
+describe('getTransLink', () => {
+  it('returns slug for english language', () => {
+    expect(getTransLink('en', 'article')).toBe('article')
+  })
+  it('adds prefix for other languages', () => {
+    expect(getTransLink('de', 'artikel')).toBe('/de/artikel')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## Summary
- set up `vitest` for testing
- add example tests for Button component and a utility
- add CI workflow running lint and tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @eslint/js not found)*

------
https://chatgpt.com/codex/tasks/task_e_684007e7d2cc833292bc8944fe1a2610