### PR TITLE
Add ESLint Astro integration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,9 +3,24 @@ import tseslint from "typescript-eslint";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import jsxA11y from "eslint-plugin-jsx-a11y";
+import astro from "eslint-plugin-astro";
+import astroParser from "astro-eslint-parser";
 
 export default [
   js.configs.recommended,
+  astro.configs["flat/recommended"],
+  {
+    files: ["**/*.astro"],
+    languageOptions: {
+      parser: astroParser,
+      parserOptions: {
+        parser: tseslint.parser,
+      },
+    },
+    plugins: {
+      astro,
+    },
+  },
   ...tseslint.configs.recommended,
   {
     files: ["**/*.ts", "**/*.tsx"],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-astro": "^0.31.0",
+    "astro-eslint-parser": "^0.25.0",
     "husky": "^9.1.7",
     "prettier": "^3.5.3",
     "stylelint": "^16.19.1",


### PR DESCRIPTION
## Summary
- add `eslint-plugin-astro` and `astro-eslint-parser`
- configure ESLint for Astro files with `astro.configs["flat/recommended"]`
- parse `.astro` files with `astro-eslint-parser`

## Testing
- `npm run eslint` *(fails: Cannot find package '@eslint/js')*
- `npm run stylelint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405794288483328c85f816623ada3a