### PR TITLE
Add node tests and engine requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ Users should be able to:
 
 ## Setup
 
-1. Clone the repository and install dependencies:
+1. Ensure you are using **Node.js 20** or newer.
+2. Clone the repository and install dependencies:
 
    ```bash
    npm install
    ```
 
-2. Create an `.env` file based on the variables described in [Environment variables](#environment-variables).
-3. Start the development server:
+3. Create an `.env` file based on the variables described in [Environment variables](#environment-variables).
+4. Start the development server:
 
    ```bash
    npm run dev

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "astro-project",
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "test": "node --test",
     "eslint": "eslint ./src",
     "stylelint": "stylelint **/*.css",
     "stylelint:fix": "stylelint **/*.css --fix",

--- a/src/system/utils/lang.test.js
+++ b/src/system/utils/lang.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getTransLink } from './lang.js';
+
+test('returns slug for English', () => {
+  assert.equal(getTransLink('en', 'home'), 'home');
+});
+
+test('prefixes slug with language for non-English', () => {
+  assert.equal(getTransLink('de', 'home'), '/de/home');
+});


### PR DESCRIPTION
## Summary
- require Node.js 20 in the project
- document the Node.js requirement in README
- add built-in Node test script
- create tests for the language utility

## Testing
- `npm run eslint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: astro: not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68417d07930c83329e12ebd1e8b8d521